### PR TITLE
파일 추가 안된거 수정

### DIFF
--- a/News.xcodeproj/project.pbxproj
+++ b/News.xcodeproj/project.pbxproj
@@ -20,6 +20,8 @@
 		B8980EB423FBC8E3000E2C21 /* NewsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8980EB323FBC8E3000E2C21 /* NewsTests.swift */; };
 		B8980EBE23FBC9AD000E2C21 /* NewsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8980EBD23FBC9AD000E2C21 /* NewsService.swift */; };
 		B8980EC023FBCB7A000E2C21 /* NewsServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8980EBF23FBCB7A000E2C21 /* NewsServiceTests.swift */; };
+		F71579B623FFEC1B00503701 /* Source.swift in Sources */ = {isa = PBXBuildFile; fileRef = F71579B523FFEC1B00503701 /* Source.swift */; };
+		F71579B823FFEC9D00503701 /* NewsProviderResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = F71579B723FFEC9D00503701 /* NewsProviderResponse.swift */; };
 		F739DD9F23F3B91B00FCD714 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F739DD9E23F3B91B00FCD714 /* AppDelegate.swift */; };
 		F739DDA123F3B91B00FCD714 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F739DDA023F3B91B00FCD714 /* SceneDelegate.swift */; };
 		F739DDA323F3B91B00FCD714 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F739DDA223F3B91B00FCD714 /* ViewController.swift */; };
@@ -60,6 +62,8 @@
 		CEBD56CF349E0D18813E8FD6 /* Pods_News.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_News.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D2C6F4BBD977E863562ECDA0 /* Pods-NewsTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NewsTests.release.xcconfig"; path = "Target Support Files/Pods-NewsTests/Pods-NewsTests.release.xcconfig"; sourceTree = "<group>"; };
 		EA28F204EB106DB7B3FD1BFF /* Pods-NewsTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NewsTests.debug.xcconfig"; path = "Target Support Files/Pods-NewsTests/Pods-NewsTests.debug.xcconfig"; sourceTree = "<group>"; };
+		F71579B523FFEC1B00503701 /* Source.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Source.swift; sourceTree = "<group>"; };
+		F71579B723FFEC9D00503701 /* NewsProviderResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NewsProviderResponse.swift; sourceTree = "<group>"; };
 		F739DD9B23F3B91B00FCD714 /* News.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = News.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		F739DD9E23F3B91B00FCD714 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		F739DDA023F3B91B00FCD714 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -127,6 +131,7 @@
 		B8980E9223FBBD16000E2C21 /* Response */ = {
 			isa = PBXGroup;
 			children = (
+				F71579B723FFEC9D00503701 /* NewsProviderResponse.swift */,
 				B8980E9323FBBD16000E2C21 /* NewsResponse.swift */,
 			);
 			path = Response;
@@ -135,6 +140,7 @@
 		B8980E9423FBBD16000E2C21 /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				F71579B523FFEC1B00503701 /* Source.swift */,
 				B8980E9523FBBD16000E2C21 /* Article.swift */,
 			);
 			path = Model;
@@ -392,9 +398,11 @@
 				F77FEB3123FA71B300BDA8D7 /* NewsDetailController.swift in Sources */,
 				B8980EA023FBBD17000E2C21 /* Article.swift in Sources */,
 				B8980EA523FBBD17000E2C21 /* ACHNewsAPIError.swift in Sources */,
+				F71579B623FFEC1B00503701 /* Source.swift in Sources */,
 				F739DDB323F3D36F00FCD714 /* NewsTableViewCell.swift in Sources */,
 				F739DD9F23F3B91B00FCD714 /* AppDelegate.swift in Sources */,
 				B8980EBE23FBC9AD000E2C21 /* NewsService.swift in Sources */,
+				F71579B823FFEC9D00503701 /* NewsProviderResponse.swift in Sources */,
 				F739DDA123F3B91B00FCD714 /* SceneDelegate.swift in Sources */,
 				B8980EA423FBBD17000E2C21 /* ACHNewsRequest.swift in Sources */,
 				B8980EA623FBBD17000E2C21 /* ACHNewsClientError.swift in Sources */,


### PR DESCRIPTION
Source.swift
NewsProviderResponse.swif
파일을 xcode가 읽어오지 못해서 수정했습니다.