### PR TITLE
뉴스상세화면 추가

### DIFF
--- a/News.xcodeproj/project.pbxproj
+++ b/News.xcodeproj/project.pbxproj
@@ -20,6 +20,9 @@
 		B8980EB423FBC8E3000E2C21 /* NewsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8980EB323FBC8E3000E2C21 /* NewsTests.swift */; };
 		B8980EBE23FBC9AD000E2C21 /* NewsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8980EBD23FBC9AD000E2C21 /* NewsService.swift */; };
 		B8980EC023FBCB7A000E2C21 /* NewsServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8980EBF23FBCB7A000E2C21 /* NewsServiceTests.swift */; };
+		B8B4172E2408AC090091230F /* NewsDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8B4172C2408AC090091230F /* NewsDetailViewController.swift */; };
+		B8B4172F2408AC090091230F /* NewsDetailViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = B8B4172D2408AC090091230F /* NewsDetailViewController.xib */; };
+		B8B417312408AC2F0091230F /* NewsDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8B417302408AC2F0091230F /* NewsDetailView.swift */; };
 		F71579B623FFEC1B00503701 /* Source.swift in Sources */ = {isa = PBXBuildFile; fileRef = F71579B523FFEC1B00503701 /* Source.swift */; };
 		F71579B823FFEC9D00503701 /* NewsProviderResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = F71579B723FFEC9D00503701 /* NewsProviderResponse.swift */; };
 		F739DD9F23F3B91B00FCD714 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F739DD9E23F3B91B00FCD714 /* AppDelegate.swift */; };
@@ -59,6 +62,9 @@
 		B8980EB523FBC8E3000E2C21 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		B8980EBD23FBC9AD000E2C21 /* NewsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewsService.swift; sourceTree = "<group>"; };
 		B8980EBF23FBCB7A000E2C21 /* NewsServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewsServiceTests.swift; sourceTree = "<group>"; };
+		B8B4172C2408AC090091230F /* NewsDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewsDetailViewController.swift; sourceTree = "<group>"; };
+		B8B4172D2408AC090091230F /* NewsDetailViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = NewsDetailViewController.xib; sourceTree = "<group>"; };
+		B8B417302408AC2F0091230F /* NewsDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewsDetailView.swift; sourceTree = "<group>"; };
 		CEBD56CF349E0D18813E8FD6 /* Pods_News.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_News.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D2C6F4BBD977E863562ECDA0 /* Pods-NewsTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NewsTests.release.xcconfig"; path = "Target Support Files/Pods-NewsTests/Pods-NewsTests.release.xcconfig"; sourceTree = "<group>"; };
 		EA28F204EB106DB7B3FD1BFF /* Pods-NewsTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NewsTests.debug.xcconfig"; path = "Target Support Files/Pods-NewsTests/Pods-NewsTests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -209,6 +215,9 @@
 				F739DDAC23F3B91C00FCD714 /* Info.plist */,
 				F739DDB223F3D36F00FCD714 /* NewsTableViewCell.swift */,
 				F77FEB3023FA71B300BDA8D7 /* NewsDetailController.swift */,
+				B8B417302408AC2F0091230F /* NewsDetailView.swift */,
+				B8B4172C2408AC090091230F /* NewsDetailViewController.swift */,
+				B8B4172D2408AC090091230F /* NewsDetailViewController.xib */,
 			);
 			path = News;
 			sourceTree = "<group>";
@@ -304,6 +313,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B8B4172F2408AC090091230F /* NewsDetailViewController.xib in Resources */,
 				F739DDAB23F3B91C00FCD714 /* LaunchScreen.storyboard in Resources */,
 				F739DDA823F3B91C00FCD714 /* Assets.xcassets in Resources */,
 				F739DDA623F3B91B00FCD714 /* Main.storyboard in Resources */,
@@ -391,6 +401,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B8980EAC23FBBD7C000E2C21 /* ACHNewsClient.swift in Sources */,
+				B8B4172E2408AC090091230F /* NewsDetailViewController.swift in Sources */,
 				B8980E9F23FBBD17000E2C21 /* NewsResponse.swift in Sources */,
 				F739DDA323F3B91B00FCD714 /* MainViewController.swift in Sources */,
 				B8980EA323FBBD17000E2C21 /* HTTPMethod.swift in Sources */,
@@ -399,6 +410,7 @@
 				B8980EA023FBBD17000E2C21 /* Article.swift in Sources */,
 				B8980EA523FBBD17000E2C21 /* ACHNewsAPIError.swift in Sources */,
 				F71579B623FFEC1B00503701 /* Source.swift in Sources */,
+				B8B417312408AC2F0091230F /* NewsDetailView.swift in Sources */,
 				F739DDB323F3D36F00FCD714 /* NewsTableViewCell.swift in Sources */,
 				F739DD9F23F3B91B00FCD714 /* AppDelegate.swift in Sources */,
 				B8980EBE23FBC9AD000E2C21 /* NewsService.swift in Sources */,

--- a/News.xcodeproj/xcshareddata/xcschemes/News.xcscheme
+++ b/News.xcodeproj/xcshareddata/xcschemes/News.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1130"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "F739DD9A23F3B91B00FCD714"
+               BuildableName = "News.app"
+               BlueprintName = "News"
+               ReferencedContainer = "container:News.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F739DD9A23F3B91B00FCD714"
+            BuildableName = "News.app"
+            BlueprintName = "News"
+            ReferencedContainer = "container:News.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F739DD9A23F3B91B00FCD714"
+            BuildableName = "News.app"
+            BlueprintName = "News"
+            ReferencedContainer = "container:News.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/News/MainViewController.swift
+++ b/News/MainViewController.swift
@@ -102,8 +102,21 @@ class MainViewController: UIViewController {
                 self.sourceTableView.reloadData()
             }
         }
+        
+        
+        //REMARK: テスト
+        let barbutton = UIBarButtonItem(title: "てすと", style: .plain, target: self, action: #selector(testButtonTouched(sender:)))
+        self.navigationItem.rightBarButtonItem = barbutton
     }
    
+    //REMARK: テスト
+    @objc func testButtonTouched(sender: UIBarButtonItem) {
+        let detailVC = NewsDetailViewController(nibName: "NewsDetailViewController", bundle: nil)
+        
+        detailVC.delegate = self
+        present(detailVC, animated: true, completion: nil)
+    }
+    
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         if let id = segue.identifier, "NewsDetail" == id {
             if let controller = segue.destination as? NewsDetailController{
@@ -191,4 +204,8 @@ extension MainViewController : UIScrollViewDelegate {
     }
 }
 
-
+extension MainViewController: NewsDetailViewControllerDelegate {
+    func getNewsItems() -> [Article]? {
+        return keywardData
+    }
+}

--- a/News/NewsDetailView.swift
+++ b/News/NewsDetailView.swift
@@ -1,0 +1,43 @@
+//
+//  NewsDetailView.swift
+//  News
+//
+//  Created by j.lee on 2020/02/28.
+//  Copyright © 2020 archive-asia. All rights reserved.
+//
+
+import UIKit
+
+class NewsDetailView: UIView {
+
+    @IBOutlet weak var timeLabel: UILabel!
+    @IBOutlet weak var authorLabel: UILabel!
+    @IBOutlet weak var headingLabel: UILabel!
+    @IBOutlet weak var bodyTextView: UITextView!
+    
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        
+        // initailize UI code.
+        
+    }
+    
+    func configureView(_ model: Article) {
+        
+        //TODO: 표시 포멧을 적절히 변경하세요.
+        
+        timeLabel.text  = model.publishedAt
+        headingLabel.text = model.title
+        bodyTextView.contentOffset = .zero
+        bodyTextView.text = model.content ?? model.description
+        authorLabel.text = model.author
+    }
+    
+    func clearView() {
+        timeLabel.text  = ""
+        headingLabel.text = ""
+        bodyTextView.text = ""
+        authorLabel.text = ""
+    }
+
+}

--- a/News/NewsDetailViewController.swift
+++ b/News/NewsDetailViewController.swift
@@ -1,0 +1,246 @@
+//
+//  NewsDetailViewController.swift
+//  News
+//
+//  Created by j.lee on 2020/02/28.
+//  Copyright © 2020 archive-asia. All rights reserved.
+//
+
+import UIKit
+
+protocol NewsDetailViewControllerDelegate : class {
+    func getNewsItems() -> [Article]?
+}
+
+class NewsDetailViewController: UIViewController {
+    
+    @IBOutlet weak var detailScroll: UIScrollView!
+    @IBOutlet weak var contentView: UIStackView!
+    @IBOutlet weak var pageNavigationView: UIView!
+    @IBOutlet weak var pageLabel: UILabel!
+    @IBOutlet weak var previousArrowButton: UIButton!
+    @IBOutlet weak var nextArrowButton: UIButton!
+    @IBOutlet weak var buttonGroupView: UIView!
+    @IBOutlet weak var closeButton: UIButton!
+    
+    enum RollPageView: Int {
+        case first = 0
+        case second
+        case third
+    }
+    
+    //rolling View
+    @IBOutlet weak var pageView1: NewsDetailView!
+    @IBOutlet weak var pageView2: NewsDetailView!
+    @IBOutlet weak var pageView3: NewsDetailView!
+    
+    weak var delegate: NewsDetailViewControllerDelegate?
+
+    private var textViewScrolling = false
+    private var currentNewsIndex = 0
+    private var currentPageIndex = 0
+    private var originOffset: CGPoint!
+    private var pageViewArray: [NewsDetailView] = []
+    private var rollingCount = 3    //default
+    
+    private var newsItems = [Article]() {
+        didSet {
+            rollingCount = (newsItems.count > 3) ? 3 : newsItems.count
+        }
+    }
+    
+    //REMARK: Life cycle
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+        setupControls()
+        
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        guard let items = delegate?.getNewsItems() else {
+            return
+        }
+        newsItems = items
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        
+        detailScroll.contentOffset = CGPoint(x: detailScroll.frame.size.width * CGFloat(currentRollPage().rawValue), y: 0)
+        originOffset = detailScroll.contentOffset
+        
+        setPageView()
+    }
+        
+    override func viewDidLayoutSubviews() {
+        
+        let contentWidth = detailScroll.bounds.width * CGFloat(rollingCount)
+        
+        contentView.frame = CGRect(x: 0, y: 0,
+                                   width: contentWidth,
+                                   height: detailScroll.bounds.height)
+        
+        detailScroll.contentSize = CGSize(width: contentWidth,
+                                          height: detailScroll.bounds.height)
+        
+    }
+    
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+}
+
+//MARK: - Private
+extension NewsDetailViewController {
+    
+    private func currentRollPage() -> RollPageView {
+        
+        if rollingCount == 2 {
+            return (currentNewsIndex == 0) ? RollPageView.first :
+            (currentNewsIndex == (newsItems.count - 1)) ? RollPageView.second : RollPageView.first
+        }else if rollingCount == 1 {
+            return RollPageView.first
+        }
+        
+        return (currentNewsIndex == 0) ? RollPageView.first :
+            (currentNewsIndex == (newsItems.count - 1)) ? RollPageView.third : RollPageView.second
+    }
+    
+    // 각각의 뷰 컨텐츠를 재설정
+    private func setPageView() {
+        
+        for v in pageViewArray {
+            v.clearView()
+        }
+        
+        let page = currentRollPage()
+        let newsView = pageViewArray[page.rawValue]
+        
+        let model = newsItems[currentNewsIndex]
+        newsView.configureView(model)
+        
+        pageLabel.text = "\(currentNewsIndex + 1)/\(newsItems.count)"
+        
+        //앞뒤 데이타를 설정
+        switch page {
+            case RollPageView.first:
+            let nextNewsView = pageViewArray[RollPageView.second.rawValue]
+            if (currentNewsIndex + 1) < newsItems.count {
+                nextNewsView.configureView(newsItems[currentNewsIndex + 1])
+            }
+        case RollPageView.second:
+            let nextNewsView = pageViewArray[RollPageView.third.rawValue]
+            if (currentNewsIndex + 1) < newsItems.count {
+                nextNewsView.configureView(newsItems[currentNewsIndex + 1])
+            }
+            let previousNewsView = pageViewArray[RollPageView.first.rawValue]
+            if (currentNewsIndex - 1) > 0 {
+                previousNewsView.configureView(newsItems[currentNewsIndex - 1])
+            }
+        case RollPageView.third:
+            let previousNewsView = pageViewArray[RollPageView.first.rawValue]
+            if (currentNewsIndex - 1) > 0 {
+                previousNewsView.configureView(newsItems[currentNewsIndex - 1])
+            }
+        }
+        
+        previousArrowButton.isHidden = (currentNewsIndex == 0)
+        nextArrowButton.isHidden = (currentNewsIndex == (newsItems.count - 1))
+        
+        self.newsItems[self.currentNewsIndex] = model
+    }
+    
+    private func setupControls() {
+        
+        pageViewArray.append(pageView1)
+        pageViewArray.append(pageView2)
+        pageViewArray.append(pageView3)
+
+        pageLabel.text = ""
+    }
+}
+
+//MARK: - Actions
+extension NewsDetailViewController {
+    
+    @IBAction func closeButtonTouched(_ sender: Any) {
+        
+        dismiss(animated: true, completion: nil)
+    }
+    
+    @IBAction func previousButtonTouched(_ sender: Any) {
+        
+        if currentNewsIndex > 0 {
+            currentNewsIndex = currentNewsIndex - 1
+
+            let point = CGPoint(x: detailScroll.bounds.width * CGFloat(currentRollPage().rawValue), y: 0)
+            detailScroll.setContentOffset(point, animated: false)
+            
+            //page가 바뀔때 뷰를 다시 설정
+            setPageView()
+        }
+    }
+    
+    @IBAction func nextButtonTouched(_ sender: Any) {
+        
+        if currentNewsIndex < (newsItems.count - 1) {
+            currentNewsIndex = currentNewsIndex + 1
+
+            let point = CGPoint(x: detailScroll.bounds.width * CGFloat(currentRollPage().rawValue), y: 0)
+            detailScroll.setContentOffset(point, animated: false)
+            
+            //page가 바뀔때 뷰를 다시 설정
+            setPageView()
+        }
+    }
+}
+
+//MARK: - UIScrollViewDelegate
+extension NewsDetailViewController: UIScrollViewDelegate {
+    func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
+        
+        // 좌우로 스와이프할때의 처리를위해 초기값 임시저장
+        self.originOffset = scrollView.contentOffset;
+    }
+    
+    func scrollViewDidEndDecelerating(_ scrollView: UIScrollView){
+        var rolling = false
+        if originOffset.x > scrollView.contentOffset.x {
+            //왼쪽 스와이프
+            if currentNewsIndex > 0 {
+                currentNewsIndex = currentNewsIndex - 1
+                rolling = true
+            }
+            
+        } else if originOffset.x < scrollView.contentOffset.x {
+            //오른쪽 스와이프
+            if currentNewsIndex < (newsItems.count - 1) {
+                currentNewsIndex = currentNewsIndex + 1
+                rolling = true
+            }
+        }
+        
+        if rolling {
+            // scrollView의 스크롤을 중앙으로 돌림
+            let point = CGPoint(x: scrollView.bounds.width * CGFloat(currentRollPage().rawValue), y: 0)
+            scrollView.setContentOffset(point, animated: false)
+            // page가 바뀌면 다시 설정
+            setPageView()
+        }
+        
+    }
+}

--- a/News/NewsDetailViewController.xib
+++ b/News/NewsDetailViewController.xib
@@ -1,0 +1,458 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="NewsDetailViewController" customModule="News" customModuleProvider="target">
+            <connections>
+                <outlet property="buttonGroupView" destination="Lm8-UN-Zxr" id="761-sr-Icl"/>
+                <outlet property="closeButton" destination="mSt-dc-V5J" id="70Q-d5-6Cu"/>
+                <outlet property="contentView" destination="gpO-2P-eaS" id="fdv-F8-Q1j"/>
+                <outlet property="detailScroll" destination="E2y-vY-c6i" id="EKA-A0-PXf"/>
+                <outlet property="nextArrowButton" destination="B8w-ul-WRX" id="CFV-YK-6tk"/>
+                <outlet property="pageLabel" destination="3Bj-f5-0B2" id="ALc-no-m0w"/>
+                <outlet property="pageNavigationView" destination="kfT-qv-vTG" id="MpD-El-VKQ"/>
+                <outlet property="pageView1" destination="bHZ-uf-gmf" id="iWg-F7-J9W"/>
+                <outlet property="pageView2" destination="aqW-5c-U3M" id="TmS-ca-DOw"/>
+                <outlet property="pageView3" destination="p5g-la-Ied" id="NRK-F7-6WA"/>
+                <outlet property="previousArrowButton" destination="al4-fu-3zt" id="IfZ-jj-P1k"/>
+                <outlet property="view" destination="HRb-Am-GWY" id="78r-xe-sDx"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="HRb-Am-GWY">
+            <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" pagingEnabled="YES" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" translatesAutoresizingMaskIntoConstraints="NO" id="E2y-vY-c6i">
+                    <rect key="frame" x="0.0" y="44" width="414" height="702"/>
+                    <subviews>
+                        <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="gpO-2P-eaS">
+                            <rect key="frame" x="0.0" y="0.0" width="1242" height="702"/>
+                            <subviews>
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bHZ-uf-gmf" userLabel="News View1" customClass="NewsDetailView" customModule="News" customModuleProvider="target">
+                                    <rect key="frame" x="0.0" y="0.0" width="414" height="702"/>
+                                    <subviews>
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="JOz-DY-AQD" userLabel="Header View">
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="100"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Xvi-Ti-QLG">
+                                                    <rect key="frame" x="16" y="16" width="35.5" height="16"/>
+                                                    <color key="backgroundColor" systemColor="systemYellowColor" red="1" green="0.80000000000000004" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="height" constant="16" id="8dd-DD-aDt"/>
+                                                    </constraints>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                    <color key="textColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    <nil key="highlightedColor"/>
+                                                    <userDefinedRuntimeAttributes>
+                                                        <userDefinedRuntimeAttribute type="color" keyPath="backgroundColor">
+                                                            <color key="value" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                        </userDefinedRuntimeAttribute>
+                                                    </userDefinedRuntimeAttributes>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xyu-3i-5B5">
+                                                    <rect key="frame" x="362.5" y="15.5" width="35.5" height="17"/>
+                                                    <color key="backgroundColor" systemColor="systemYellowColor" red="1" green="0.80000000000000004" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                    <color key="textColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    <nil key="highlightedColor"/>
+                                                    <userDefinedRuntimeAttributes>
+                                                        <userDefinedRuntimeAttribute type="color" keyPath="backgroundColor">
+                                                            <color key="value" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                        </userDefinedRuntimeAttribute>
+                                                    </userDefinedRuntimeAttributes>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="igK-vh-Ir3">
+                                                    <rect key="frame" x="16" y="40.5" width="382" height="50.5"/>
+                                                    <fontDescription key="fontDescription" type="system" weight="medium" pointSize="21"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                    <userDefinedRuntimeAttributes>
+                                                        <userDefinedRuntimeAttribute type="color" keyPath="backgroundColor">
+                                                            <color key="value" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                        </userDefinedRuntimeAttribute>
+                                                    </userDefinedRuntimeAttributes>
+                                                </label>
+                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BUl-Rz-jOa" userLabel="Line View">
+                                                    <rect key="frame" x="16" y="99" width="382" height="1"/>
+                                                    <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="height" constant="1" id="ufl-it-TQa"/>
+                                                    </constraints>
+                                                </view>
+                                            </subviews>
+                                            <color key="backgroundColor" systemColor="systemOrangeColor" red="1" green="0.58431372550000005" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            <constraints>
+                                                <constraint firstItem="Xvi-Ti-QLG" firstAttribute="leading" secondItem="JOz-DY-AQD" secondAttribute="leading" constant="16" id="8Pr-96-BBv"/>
+                                                <constraint firstAttribute="trailing" secondItem="igK-vh-Ir3" secondAttribute="trailing" constant="16" id="AJU-7g-36W"/>
+                                                <constraint firstItem="igK-vh-Ir3" firstAttribute="top" secondItem="xyu-3i-5B5" secondAttribute="bottom" constant="8" id="Bfs-Vq-dJX"/>
+                                                <constraint firstItem="Xvi-Ti-QLG" firstAttribute="leading" secondItem="JOz-DY-AQD" secondAttribute="leading" constant="16" id="E7d-MJ-Onv"/>
+                                                <constraint firstItem="BUl-Rz-jOa" firstAttribute="top" secondItem="igK-vh-Ir3" secondAttribute="bottom" constant="8" id="EAX-Tr-uPv"/>
+                                                <constraint firstAttribute="trailing" secondItem="xyu-3i-5B5" secondAttribute="trailing" constant="16" id="NSw-RY-G0h"/>
+                                                <constraint firstAttribute="bottom" secondItem="BUl-Rz-jOa" secondAttribute="bottom" id="RoM-nt-ZLo"/>
+                                                <constraint firstItem="Xvi-Ti-QLG" firstAttribute="top" secondItem="JOz-DY-AQD" secondAttribute="top" constant="16" id="bZK-b1-Llz"/>
+                                                <constraint firstAttribute="height" constant="100" id="fuT-E7-4tw"/>
+                                                <constraint firstItem="igK-vh-Ir3" firstAttribute="leading" secondItem="JOz-DY-AQD" secondAttribute="leading" constant="16" id="m0K-Dc-QS2"/>
+                                                <constraint firstItem="BUl-Rz-jOa" firstAttribute="leading" secondItem="JOz-DY-AQD" secondAttribute="leading" constant="16" id="uqn-Z3-4sg"/>
+                                                <constraint firstItem="xyu-3i-5B5" firstAttribute="centerY" secondItem="Xvi-Ti-QLG" secondAttribute="centerY" id="wy4-5T-Rt1"/>
+                                                <constraint firstAttribute="trailing" secondItem="BUl-Rz-jOa" secondAttribute="trailing" constant="16" id="xuQ-1I-3PI"/>
+                                            </constraints>
+                                            <userDefinedRuntimeAttributes>
+                                                <userDefinedRuntimeAttribute type="color" keyPath="backgroundColor">
+                                                    <color key="value" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                </userDefinedRuntimeAttribute>
+                                            </userDefinedRuntimeAttributes>
+                                        </view>
+                                        <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" editable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="I51-Pu-3V2">
+                                            <rect key="frame" x="0.0" y="100" width="414" height="602"/>
+                                            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                            <color key="textColor" systemColor="labelColor" cocoaTouchSystemColor="darkTextColor"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                            <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                                        </textView>
+                                    </subviews>
+                                    <color key="backgroundColor" systemColor="systemTealColor" red="0.35294117650000001" green="0.7843137255" blue="0.98039215690000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                    <constraints>
+                                        <constraint firstItem="JOz-DY-AQD" firstAttribute="leading" secondItem="bHZ-uf-gmf" secondAttribute="leading" id="2Zs-96-ChE"/>
+                                        <constraint firstAttribute="trailing" secondItem="JOz-DY-AQD" secondAttribute="trailing" id="3fi-iM-xwr"/>
+                                        <constraint firstItem="I51-Pu-3V2" firstAttribute="leading" secondItem="bHZ-uf-gmf" secondAttribute="leading" id="CG0-Zo-u2e"/>
+                                        <constraint firstAttribute="trailing" secondItem="I51-Pu-3V2" secondAttribute="trailing" id="Nhl-Q8-y2J"/>
+                                        <constraint firstAttribute="bottom" secondItem="I51-Pu-3V2" secondAttribute="bottom" id="SLD-Aa-V0P"/>
+                                        <constraint firstItem="I51-Pu-3V2" firstAttribute="top" secondItem="JOz-DY-AQD" secondAttribute="bottom" id="agd-p1-5xF"/>
+                                        <constraint firstItem="JOz-DY-AQD" firstAttribute="top" secondItem="bHZ-uf-gmf" secondAttribute="top" id="riZ-oi-d8o"/>
+                                    </constraints>
+                                    <userDefinedRuntimeAttributes>
+                                        <userDefinedRuntimeAttribute type="color" keyPath="backgroundColor">
+                                            <color key="value" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        </userDefinedRuntimeAttribute>
+                                    </userDefinedRuntimeAttributes>
+                                    <connections>
+                                        <outlet property="authorLabel" destination="xyu-3i-5B5" id="B86-nZ-wTQ"/>
+                                        <outlet property="bodyTextView" destination="I51-Pu-3V2" id="Bka-YD-H10"/>
+                                        <outlet property="headingLabel" destination="igK-vh-Ir3" id="edm-w0-poY"/>
+                                        <outlet property="timeLabel" destination="Xvi-Ti-QLG" id="dxA-Wg-4rf"/>
+                                    </connections>
+                                </view>
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="aqW-5c-U3M" userLabel="News View2" customClass="NewsDetailView" customModule="News" customModuleProvider="target">
+                                    <rect key="frame" x="414" y="0.0" width="414" height="702"/>
+                                    <subviews>
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4e5-W1-haP" userLabel="Header View">
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="100"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="r1h-WL-3d4">
+                                                    <rect key="frame" x="16" y="16" width="35.5" height="16"/>
+                                                    <color key="backgroundColor" systemColor="systemYellowColor" red="1" green="0.80000000000000004" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="height" constant="16" id="789-AT-sFp"/>
+                                                    </constraints>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                    <color key="textColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    <nil key="highlightedColor"/>
+                                                    <userDefinedRuntimeAttributes>
+                                                        <userDefinedRuntimeAttribute type="color" keyPath="backgroundColor">
+                                                            <color key="value" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                        </userDefinedRuntimeAttribute>
+                                                    </userDefinedRuntimeAttributes>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KbC-lM-7tj">
+                                                    <rect key="frame" x="362.5" y="15.5" width="35.5" height="17"/>
+                                                    <color key="backgroundColor" systemColor="systemYellowColor" red="1" green="0.80000000000000004" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                    <color key="textColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    <nil key="highlightedColor"/>
+                                                    <userDefinedRuntimeAttributes>
+                                                        <userDefinedRuntimeAttribute type="color" keyPath="backgroundColor">
+                                                            <color key="value" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                        </userDefinedRuntimeAttribute>
+                                                    </userDefinedRuntimeAttributes>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gPJ-7I-Uav">
+                                                    <rect key="frame" x="16" y="36.5" width="382" height="54.5"/>
+                                                    <fontDescription key="fontDescription" type="system" weight="medium" pointSize="21"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                    <userDefinedRuntimeAttributes>
+                                                        <userDefinedRuntimeAttribute type="color" keyPath="backgroundColor">
+                                                            <color key="value" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                        </userDefinedRuntimeAttribute>
+                                                    </userDefinedRuntimeAttributes>
+                                                </label>
+                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="kLX-jE-36V" userLabel="Line View">
+                                                    <rect key="frame" x="16" y="99" width="382" height="1"/>
+                                                    <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="height" constant="1" id="8cO-yt-Zfm"/>
+                                                    </constraints>
+                                                </view>
+                                            </subviews>
+                                            <color key="backgroundColor" systemColor="systemOrangeColor" red="1" green="0.58431372550000005" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            <constraints>
+                                                <constraint firstItem="gPJ-7I-Uav" firstAttribute="leading" secondItem="4e5-W1-haP" secondAttribute="leading" constant="16" id="B7V-4U-5VQ"/>
+                                                <constraint firstItem="r1h-WL-3d4" firstAttribute="leading" secondItem="4e5-W1-haP" secondAttribute="leading" constant="16" id="Bvl-0k-JdL"/>
+                                                <constraint firstAttribute="trailing" secondItem="gPJ-7I-Uav" secondAttribute="trailing" constant="16" id="ELY-iL-cKz"/>
+                                                <constraint firstItem="kLX-jE-36V" firstAttribute="top" secondItem="gPJ-7I-Uav" secondAttribute="bottom" constant="8" id="J3j-Up-iln"/>
+                                                <constraint firstItem="KbC-lM-7tj" firstAttribute="centerY" secondItem="r1h-WL-3d4" secondAttribute="centerY" id="O5G-sj-RsO"/>
+                                                <constraint firstAttribute="height" constant="100" id="P3L-sT-1so"/>
+                                                <constraint firstAttribute="bottom" secondItem="kLX-jE-36V" secondAttribute="bottom" id="QTh-lo-M0o"/>
+                                                <constraint firstItem="r1h-WL-3d4" firstAttribute="top" secondItem="4e5-W1-haP" secondAttribute="top" constant="16" id="WSy-yp-e9I"/>
+                                                <constraint firstItem="gPJ-7I-Uav" firstAttribute="top" secondItem="KbC-lM-7tj" secondAttribute="bottom" constant="4" id="b5L-TT-vil"/>
+                                                <constraint firstItem="kLX-jE-36V" firstAttribute="leading" secondItem="4e5-W1-haP" secondAttribute="leading" constant="16" id="bb1-li-fDi"/>
+                                                <constraint firstAttribute="trailing" secondItem="KbC-lM-7tj" secondAttribute="trailing" constant="16" id="e46-wX-RkX"/>
+                                                <constraint firstItem="r1h-WL-3d4" firstAttribute="leading" secondItem="4e5-W1-haP" secondAttribute="leading" constant="16" id="kH2-bb-VAQ"/>
+                                                <constraint firstAttribute="trailing" secondItem="kLX-jE-36V" secondAttribute="trailing" constant="16" id="ngc-xe-yHe"/>
+                                            </constraints>
+                                            <userDefinedRuntimeAttributes>
+                                                <userDefinedRuntimeAttribute type="color" keyPath="backgroundColor">
+                                                    <color key="value" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                </userDefinedRuntimeAttribute>
+                                            </userDefinedRuntimeAttributes>
+                                        </view>
+                                        <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" editable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4Jk-0F-wO6">
+                                            <rect key="frame" x="0.0" y="100" width="414" height="602"/>
+                                            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                            <color key="textColor" systemColor="labelColor" cocoaTouchSystemColor="darkTextColor"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                            <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                                        </textView>
+                                    </subviews>
+                                    <color key="backgroundColor" systemColor="systemTealColor" red="0.35294117650000001" green="0.7843137255" blue="0.98039215690000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                    <constraints>
+                                        <constraint firstAttribute="trailing" secondItem="4Jk-0F-wO6" secondAttribute="trailing" id="2ez-94-889"/>
+                                        <constraint firstItem="4e5-W1-haP" firstAttribute="top" secondItem="aqW-5c-U3M" secondAttribute="top" id="FDU-mZ-e1F"/>
+                                        <constraint firstItem="4e5-W1-haP" firstAttribute="leading" secondItem="aqW-5c-U3M" secondAttribute="leading" id="VDb-Od-Wu1"/>
+                                        <constraint firstItem="4Jk-0F-wO6" firstAttribute="top" secondItem="4e5-W1-haP" secondAttribute="bottom" id="Yat-bO-Yqa"/>
+                                        <constraint firstItem="4Jk-0F-wO6" firstAttribute="leading" secondItem="aqW-5c-U3M" secondAttribute="leading" id="iaL-6d-JiK"/>
+                                        <constraint firstAttribute="bottom" secondItem="4Jk-0F-wO6" secondAttribute="bottom" id="olb-2O-fmh"/>
+                                        <constraint firstAttribute="trailing" secondItem="4e5-W1-haP" secondAttribute="trailing" id="u0Q-vj-aa7"/>
+                                    </constraints>
+                                    <userDefinedRuntimeAttributes>
+                                        <userDefinedRuntimeAttribute type="color" keyPath="backgroundColor">
+                                            <color key="value" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        </userDefinedRuntimeAttribute>
+                                    </userDefinedRuntimeAttributes>
+                                    <connections>
+                                        <outlet property="authorLabel" destination="KbC-lM-7tj" id="LUq-h7-A4U"/>
+                                        <outlet property="bodyTextView" destination="4Jk-0F-wO6" id="nbj-sH-SQG"/>
+                                        <outlet property="headingLabel" destination="gPJ-7I-Uav" id="drb-SR-wkr"/>
+                                        <outlet property="timeLabel" destination="r1h-WL-3d4" id="PsP-pN-t78"/>
+                                    </connections>
+                                </view>
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="p5g-la-Ied" userLabel="News View3" customClass="NewsDetailView" customModule="News" customModuleProvider="target">
+                                    <rect key="frame" x="828" y="0.0" width="414" height="702"/>
+                                    <subviews>
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="HHY-GH-3mP" userLabel="Header View">
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="100"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="AuA-zy-9zA">
+                                                    <rect key="frame" x="16" y="16" width="35.5" height="16"/>
+                                                    <color key="backgroundColor" systemColor="systemYellowColor" red="1" green="0.80000000000000004" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="height" constant="16" id="tZx-rh-A0d"/>
+                                                    </constraints>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                    <color key="textColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    <nil key="highlightedColor"/>
+                                                    <userDefinedRuntimeAttributes>
+                                                        <userDefinedRuntimeAttribute type="color" keyPath="backgroundColor">
+                                                            <color key="value" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                        </userDefinedRuntimeAttribute>
+                                                    </userDefinedRuntimeAttributes>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vcH-8q-4F7">
+                                                    <rect key="frame" x="362.5" y="15.5" width="35.5" height="17"/>
+                                                    <color key="backgroundColor" systemColor="systemYellowColor" red="1" green="0.80000000000000004" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                    <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    <nil key="highlightedColor"/>
+                                                    <userDefinedRuntimeAttributes>
+                                                        <userDefinedRuntimeAttribute type="color" keyPath="backgroundColor">
+                                                            <color key="value" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                        </userDefinedRuntimeAttribute>
+                                                    </userDefinedRuntimeAttributes>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HxC-Ev-lkG">
+                                                    <rect key="frame" x="16" y="65.5" width="382" height="25.5"/>
+                                                    <fontDescription key="fontDescription" type="system" weight="medium" pointSize="21"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                    <userDefinedRuntimeAttributes>
+                                                        <userDefinedRuntimeAttribute type="color" keyPath="backgroundColor">
+                                                            <color key="value" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                        </userDefinedRuntimeAttribute>
+                                                    </userDefinedRuntimeAttributes>
+                                                </label>
+                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="rR7-7w-N3S" userLabel="Line View">
+                                                    <rect key="frame" x="16" y="99" width="382" height="1"/>
+                                                    <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="height" constant="1" id="fPI-BJ-LZg"/>
+                                                    </constraints>
+                                                </view>
+                                            </subviews>
+                                            <color key="backgroundColor" systemColor="systemOrangeColor" red="1" green="0.58431372550000005" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            <constraints>
+                                                <constraint firstAttribute="trailing" secondItem="HxC-Ev-lkG" secondAttribute="trailing" constant="16" id="DSt-f4-jQE"/>
+                                                <constraint firstAttribute="height" constant="100" id="Jve-jK-Los"/>
+                                                <constraint firstItem="HxC-Ev-lkG" firstAttribute="leading" secondItem="HHY-GH-3mP" secondAttribute="leading" constant="16" id="VzE-es-nyX"/>
+                                                <constraint firstItem="rR7-7w-N3S" firstAttribute="leading" secondItem="HHY-GH-3mP" secondAttribute="leading" constant="16" id="aa6-jT-fIx"/>
+                                                <constraint firstItem="AuA-zy-9zA" firstAttribute="top" secondItem="HHY-GH-3mP" secondAttribute="top" constant="16" id="cyR-vC-CE9"/>
+                                                <constraint firstItem="AuA-zy-9zA" firstAttribute="leading" secondItem="HHY-GH-3mP" secondAttribute="leading" constant="16" id="dZC-fV-ebd"/>
+                                                <constraint firstItem="AuA-zy-9zA" firstAttribute="leading" secondItem="HHY-GH-3mP" secondAttribute="leading" constant="16" id="eZY-rU-MR2"/>
+                                                <constraint firstAttribute="trailing" secondItem="rR7-7w-N3S" secondAttribute="trailing" constant="16" id="gUF-iF-6dx"/>
+                                                <constraint firstAttribute="bottom" secondItem="rR7-7w-N3S" secondAttribute="bottom" id="ibN-Gy-zoI"/>
+                                                <constraint firstAttribute="trailing" secondItem="vcH-8q-4F7" secondAttribute="trailing" constant="16" id="obf-3c-ecV"/>
+                                                <constraint firstItem="rR7-7w-N3S" firstAttribute="top" secondItem="HxC-Ev-lkG" secondAttribute="bottom" constant="8" id="tLK-bu-znS"/>
+                                                <constraint firstItem="vcH-8q-4F7" firstAttribute="centerY" secondItem="AuA-zy-9zA" secondAttribute="centerY" id="x1T-kS-4u8"/>
+                                            </constraints>
+                                            <userDefinedRuntimeAttributes>
+                                                <userDefinedRuntimeAttribute type="color" keyPath="backgroundColor">
+                                                    <color key="value" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                </userDefinedRuntimeAttribute>
+                                            </userDefinedRuntimeAttributes>
+                                        </view>
+                                        <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" editable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="GH7-CB-Q59">
+                                            <rect key="frame" x="0.0" y="100" width="414" height="582"/>
+                                            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                            <color key="textColor" systemColor="labelColor" cocoaTouchSystemColor="darkTextColor"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                            <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                                        </textView>
+                                    </subviews>
+                                    <color key="backgroundColor" systemColor="systemTealColor" red="0.35294117650000001" green="0.7843137255" blue="0.98039215690000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                    <constraints>
+                                        <constraint firstItem="HHY-GH-3mP" firstAttribute="leading" secondItem="p5g-la-Ied" secondAttribute="leading" id="6qY-zW-W25"/>
+                                        <constraint firstItem="HHY-GH-3mP" firstAttribute="top" secondItem="p5g-la-Ied" secondAttribute="top" id="EBu-eF-e8X"/>
+                                        <constraint firstAttribute="bottom" secondItem="GH7-CB-Q59" secondAttribute="bottom" constant="20" symbolic="YES" id="HQL-Vt-5s1"/>
+                                        <constraint firstAttribute="trailing" secondItem="GH7-CB-Q59" secondAttribute="trailing" id="U2P-eo-rvv"/>
+                                        <constraint firstItem="GH7-CB-Q59" firstAttribute="top" secondItem="HHY-GH-3mP" secondAttribute="bottom" id="Y4c-b8-Yr6"/>
+                                        <constraint firstAttribute="trailing" secondItem="HHY-GH-3mP" secondAttribute="trailing" id="cHj-el-5Mj"/>
+                                        <constraint firstItem="GH7-CB-Q59" firstAttribute="leading" secondItem="p5g-la-Ied" secondAttribute="leading" id="zFF-Ab-wwn"/>
+                                    </constraints>
+                                    <userDefinedRuntimeAttributes>
+                                        <userDefinedRuntimeAttribute type="color" keyPath="backgroundColor">
+                                            <color key="value" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        </userDefinedRuntimeAttribute>
+                                    </userDefinedRuntimeAttributes>
+                                    <connections>
+                                        <outlet property="authorLabel" destination="vcH-8q-4F7" id="RyJ-36-DAo"/>
+                                        <outlet property="bodyTextView" destination="GH7-CB-Q59" id="94U-SL-zKd"/>
+                                        <outlet property="headingLabel" destination="HxC-Ev-lkG" id="bt7-Wg-MY3"/>
+                                        <outlet property="timeLabel" destination="AuA-zy-9zA" id="4gU-ed-q7T"/>
+                                    </connections>
+                                </view>
+                            </subviews>
+                        </stackView>
+                    </subviews>
+                    <constraints>
+                        <constraint firstItem="gpO-2P-eaS" firstAttribute="top" secondItem="E2y-vY-c6i" secondAttribute="top" id="DAU-hy-glr"/>
+                        <constraint firstItem="bHZ-uf-gmf" firstAttribute="height" secondItem="E2y-vY-c6i" secondAttribute="height" id="Gny-69-yZq"/>
+                        <constraint firstAttribute="bottom" secondItem="gpO-2P-eaS" secondAttribute="bottom" id="IZ6-kU-wux"/>
+                        <constraint firstAttribute="trailing" secondItem="gpO-2P-eaS" secondAttribute="trailing" id="Z7r-8N-ZSh"/>
+                        <constraint firstItem="gpO-2P-eaS" firstAttribute="leading" secondItem="E2y-vY-c6i" secondAttribute="leading" id="iUB-6x-lVI"/>
+                        <constraint firstItem="bHZ-uf-gmf" firstAttribute="width" secondItem="E2y-vY-c6i" secondAttribute="width" id="yy9-Gm-nbH"/>
+                    </constraints>
+                    <viewLayoutGuide key="contentLayoutGuide" id="vai-ri-Czh"/>
+                    <viewLayoutGuide key="frameLayoutGuide" id="3dp-6D-kMb"/>
+                    <connections>
+                        <outlet property="delegate" destination="-1" id="0Ud-11-arY"/>
+                    </connections>
+                </scrollView>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="kfT-qv-vTG" userLabel="Page Navigation View">
+                    <rect key="frame" x="0.0" y="746" width="414" height="60"/>
+                    <subviews>
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="al4-fu-3zt">
+                            <rect key="frame" x="16" y="10" width="60" height="40"/>
+                            <constraints>
+                                <constraint firstAttribute="width" constant="60" id="Xt5-ng-9aQ"/>
+                                <constraint firstAttribute="height" constant="40" id="yk5-Dh-XD3"/>
+                            </constraints>
+                            <fontDescription key="fontDescription" type="boldSystem" pointSize="21"/>
+                            <state key="normal" title="&lt;"/>
+                            <connections>
+                                <action selector="previousButtonTouched:" destination="-1" eventType="touchUpInside" id="ula-M3-laH"/>
+                            </connections>
+                        </button>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3Bj-f5-0B2">
+                            <rect key="frame" x="177" y="15.5" width="60" height="29"/>
+                            <color key="backgroundColor" red="0.4434924126" green="0.66354233029999998" blue="0.66059458260000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                            <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="24"/>
+                            <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            <nil key="highlightedColor"/>
+                            <userDefinedRuntimeAttributes>
+                                <userDefinedRuntimeAttribute type="color" keyPath="backgroundColor">
+                                    <color key="value" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                </userDefinedRuntimeAttribute>
+                            </userDefinedRuntimeAttributes>
+                        </label>
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="B8w-ul-WRX">
+                            <rect key="frame" x="338" y="10" width="60" height="40"/>
+                            <constraints>
+                                <constraint firstAttribute="width" constant="60" id="61n-xa-2zT"/>
+                                <constraint firstAttribute="height" constant="40" id="QFK-BZ-9mk"/>
+                            </constraints>
+                            <fontDescription key="fontDescription" type="boldSystem" pointSize="21"/>
+                            <state key="normal" title="&gt;"/>
+                            <connections>
+                                <action selector="nextButtonTouched:" destination="-1" eventType="touchUpInside" id="7Fa-c8-0uG"/>
+                            </connections>
+                        </button>
+                    </subviews>
+                    <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    <constraints>
+                        <constraint firstItem="B8w-ul-WRX" firstAttribute="centerY" secondItem="kfT-qv-vTG" secondAttribute="centerY" id="EwF-eg-u0W"/>
+                        <constraint firstItem="3Bj-f5-0B2" firstAttribute="centerX" secondItem="kfT-qv-vTG" secondAttribute="centerX" id="F0T-wg-OH8"/>
+                        <constraint firstAttribute="trailing" secondItem="B8w-ul-WRX" secondAttribute="trailing" constant="16" id="aNY-ap-deb"/>
+                        <constraint firstAttribute="height" constant="60" id="bYQ-ua-6c3"/>
+                        <constraint firstItem="al4-fu-3zt" firstAttribute="centerY" secondItem="kfT-qv-vTG" secondAttribute="centerY" id="noG-tn-pM9"/>
+                        <constraint firstItem="3Bj-f5-0B2" firstAttribute="centerY" secondItem="kfT-qv-vTG" secondAttribute="centerY" id="txA-z6-dYc"/>
+                        <constraint firstItem="al4-fu-3zt" firstAttribute="leading" secondItem="kfT-qv-vTG" secondAttribute="leading" constant="16" id="wpU-9Y-jVy"/>
+                    </constraints>
+                </view>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Lm8-UN-Zxr" userLabel="Button Container View">
+                    <rect key="frame" x="0.0" y="806" width="414" height="56"/>
+                    <subviews>
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="mSt-dc-V5J">
+                            <rect key="frame" x="162" y="10" width="90" height="36"/>
+                            <constraints>
+                                <constraint firstAttribute="width" constant="90" id="CCI-gA-0e6"/>
+                                <constraint firstAttribute="height" constant="36" id="tD9-Ps-dq9"/>
+                            </constraints>
+                            <state key="normal" title="閉じる"/>
+                            <connections>
+                                <action selector="closeButtonTouched:" destination="-1" eventType="touchUpInside" id="z8A-1i-Ow1"/>
+                            </connections>
+                        </button>
+                    </subviews>
+                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    <constraints>
+                        <constraint firstItem="mSt-dc-V5J" firstAttribute="centerY" secondItem="Lm8-UN-Zxr" secondAttribute="centerY" id="B0c-1q-xxr"/>
+                        <constraint firstAttribute="height" constant="56" id="HRc-NI-0G4"/>
+                        <constraint firstAttribute="bottom" secondItem="mSt-dc-V5J" secondAttribute="bottom" constant="10" id="Q6a-8a-kKx"/>
+                        <constraint firstItem="mSt-dc-V5J" firstAttribute="centerX" secondItem="Lm8-UN-Zxr" secondAttribute="centerX" id="TH7-vw-yae"/>
+                        <constraint firstItem="mSt-dc-V5J" firstAttribute="top" secondItem="Lm8-UN-Zxr" secondAttribute="top" constant="10" id="cV2-uA-khh"/>
+                    </constraints>
+                </view>
+            </subviews>
+            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <constraints>
+                <constraint firstItem="Lm8-UN-Zxr" firstAttribute="leading" secondItem="HRb-Am-GWY" secondAttribute="leading" id="26m-vN-jVb"/>
+                <constraint firstItem="7ET-3k-mk1" firstAttribute="trailing" secondItem="Lm8-UN-Zxr" secondAttribute="trailing" id="5Zl-G7-cPp"/>
+                <constraint firstItem="7ET-3k-mk1" firstAttribute="trailing" secondItem="kfT-qv-vTG" secondAttribute="trailing" id="990-by-d5x"/>
+                <constraint firstItem="E2y-vY-c6i" firstAttribute="top" secondItem="7ET-3k-mk1" secondAttribute="top" id="B1e-ut-HQ1"/>
+                <constraint firstItem="7ET-3k-mk1" firstAttribute="bottom" secondItem="Lm8-UN-Zxr" secondAttribute="bottom" id="Ugc-80-sxm"/>
+                <constraint firstItem="Lm8-UN-Zxr" firstAttribute="top" secondItem="kfT-qv-vTG" secondAttribute="bottom" id="VT1-aF-Jxq"/>
+                <constraint firstItem="kfT-qv-vTG" firstAttribute="leading" secondItem="7ET-3k-mk1" secondAttribute="leading" id="bio-KS-TZC"/>
+                <constraint firstItem="E2y-vY-c6i" firstAttribute="trailing" secondItem="7ET-3k-mk1" secondAttribute="trailing" id="jkw-nA-lpC"/>
+                <constraint firstItem="E2y-vY-c6i" firstAttribute="leading" secondItem="7ET-3k-mk1" secondAttribute="leading" id="mid-Ox-A2J"/>
+                <constraint firstItem="kfT-qv-vTG" firstAttribute="top" secondItem="E2y-vY-c6i" secondAttribute="bottom" id="z34-V6-eNr"/>
+            </constraints>
+            <viewLayoutGuide key="safeArea" id="7ET-3k-mk1"/>
+            <point key="canvasLocation" x="131.8840579710145" y="132.58928571428572"/>
+        </view>
+    </objects>
+</document>

--- a/News/NewsDetailViewProtocol.swift
+++ b/News/NewsDetailViewProtocol.swift
@@ -1,0 +1,9 @@
+//
+//  NewsDetailProtocol.swift
+//  News
+//
+//  Created by j.lee on 2020/02/28.
+//  Copyright © 2020 archive-asia. All rights reserved.
+//
+
+import Foundation


### PR DESCRIPTION
뉴스 상세화면 추가하였습니다.

- `ViewController`에는 테스트코드가 들어가 있으니 적용후 지워주세요.
- 뉴스상세 페이지 안에 데이트취득부분은 테스트용입니다. 화면구성에 맞게 적절히 수정해야 합니다.
- 표시포멧이나 데이타, 디자인등은 앱 사양을 고려하지 않았습니다. 앞으로 수정해야할 부분입니다.
- `DetailViewController` 의 코드를 정리한 부분을 보시고 참고하여 다른 `ViewController`에 적용해 주세요.
- `DetailViewController.xib` 파일은 storyboard랑 같은 기능의 리소스파일입니다. 뷰단위나 단독콘트롤러의 리소스로 분리할때 사용합니다. 지금은 신경쓰지 마세요. 