### PR TITLE
[#21]TopHeadingメニューとEveryThingメニューにイメジが出ないことがある。 

### DIFF
--- a/News/Info.plist
+++ b/News/Info.plist
@@ -25,6 +25,11 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/News/MainViewController.swift
+++ b/News/MainViewController.swift
@@ -296,11 +296,14 @@ extension MainViewController : UITableViewDataSource {
             cell.sourceLabel.text          = dataAtRow.author ?? "익명"
             cell.newsDescriptionLabel.text = dataAtRow.description
             
+            //print("dataAtRow.urlToImage: \(dataAtRow.urlToImage)")
+            
             //TODO: URL주소가 있음에도 로드가 안되는 이미지가 있다.
-            let remoteImageURL = URL(string: dataAtRow.urlToImage ??
-                "https://upload.wikimedia.org/wikipedia/ja/b/b5/Noimage_image.png")
-
-            cell.urlToImage?.sd_setImage(with: remoteImageURL)
+            if let imageString = dataAtRow.urlToImage {
+                let remoteImageURL = URL(string: imageString)
+                cell.urlToImage.setImageBySDWebImage(with: remoteImageURL)
+            }
+            
             
         } else if cellIndentifier == "EverythingTableViewCell"  {
 
@@ -310,10 +313,10 @@ extension MainViewController : UITableViewDataSource {
             cell.sourceLabel.text          = dataAtRow.author ?? "익명"
             cell.newsDescriptionLabel.text = dataAtRow.description
 
-            let remoteImageURL = URL(string: dataAtRow.urlToImage ??
-                "https://upload.wikimedia.org/wikipedia/ja/b/b5/Noimage_image.png")
-
-            cell.urlToImage?.sd_setImage(with: remoteImageURL)
+            if let imageString = dataAtRow.urlToImage {
+                let remoteImageURL = URL(string: imageString)
+                cell.urlToImage.setImageBySDWebImage(with: remoteImageURL)
+            }
 
         } else {
             let dataAtRow = providerData[indexPath.row]
@@ -517,3 +520,26 @@ extension MainViewController : UISearchBarDelegate {
     }
 }
 
+extension UIImageView {
+
+    func setImageBySDWebImage(with url: URL?) {
+
+        guard let imageUrl = url else {
+            self.backgroundColor = .lightGray
+            return
+        }
+        
+        self.sd_setImage(with: imageUrl) { [weak self] image, error, _, _ in
+            // Success
+            if error == nil, let image = image {
+                self?.image = image
+                self?.backgroundColor = .clear
+            // Failure
+            } else {
+                // error handling
+                self?.backgroundColor = .blue
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
## 개요

일부이미지가 표시안되는 문제 수정

## 원인
1. 데이타를 출력해본 결과 이미지경로가 `nil `로 들어오는것을 확인
2. 데이타 URL이 `https://`가 아닌 `http://`로 들어옴

## 수정사항

- nil로 들어오는 데이터에 한해서는 이미지 배경색을 회색으로 바꿔줌

기존로직은 외부URL로 noimage를 표시하게 되어있는데 네트워크에러의 경우는 그것마져도 표시안될 가능성이 있으므로 수정

- 아이폰(아마 안드로이드도 동일) 의 경우 보안상 `http://`는 통신이 불가함.
임시로 통신이 되게 강제설정함. 실제 릴리스에서는 사용할수 없음
참고링크 
https://qiita.com/uhooi/items/68939999c2c31e5f5557

내용확인하시고 이해하시면 됩니다. 추가수정이 필요하면 대응하세요.

